### PR TITLE
test: Add compilation verification to the regression test group

### DIFF
--- a/tyler-base/src/test/input/sequenceGenerator.xml
+++ b/tyler-base/src/test/input/sequenceGenerator.xml
@@ -1,6 +1,22 @@
 <configuration>
     <import class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator"/>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+    <import class="ch.qos.logback.core.rolling.RollingFileAppender"/>
+    <import class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy"/>
+
     <sequenceNumberGenerator class="BasicSequenceNumberGenerator"/>
+
+    <appender name="RFILE" class="RollingFileAppender">
+        <file>/tmp/logFile.log</file>
+        <rollingPolicy class="TimeBasedRollingPolicy">
+            <fileNamePattern>logFile.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%-4relative [%thread] %-5level %logger{35} -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
 
     <root level="DEBUG">
         <appender-ref ref="RFILE"/>

--- a/tyler-base/src/test/java/ch/qos/logback/tyler/base/compiler/CompilationVerifier.java
+++ b/tyler-base/src/test/java/ch/qos/logback/tyler/base/compiler/CompilationVerifier.java
@@ -1,0 +1,42 @@
+package ch.qos.logback.tyler.base.compiler;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Locale;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+
+public class CompilationVerifier {
+
+    private static final String classpath;
+
+    static {
+        String systemClasspath = System.getProperty("java.class.path");
+        String modulePath = System.getProperty("jdk.module.path");
+        if (modulePath != null && !modulePath.isBlank()) {
+            systemClasspath += ":" + modulePath;
+        }
+        classpath = systemClasspath;
+    }
+
+    public CompilerVerificationResult verify(String name, String sourceCode) {
+        final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        final DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        final JavaFileObject source = new JavaSourceFromString(name, sourceCode);
+
+        try(StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnostics, Locale.getDefault(), Charset.defaultCharset());) {
+            JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, diagnostics, List.of("-classpath", classpath), null, List.of(source));
+            boolean compilationResult = task.call();
+
+            return new CompilerVerificationResult(compilationResult, diagnostics);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+}

--- a/tyler-base/src/test/java/ch/qos/logback/tyler/base/compiler/CompilerVerificationResult.java
+++ b/tyler-base/src/test/java/ch/qos/logback/tyler/base/compiler/CompilerVerificationResult.java
@@ -1,0 +1,26 @@
+package ch.qos.logback.tyler.base.compiler;
+
+import java.util.Locale;
+import java.util.stream.Collectors;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaFileObject;
+
+public class CompilerVerificationResult {
+    private final boolean success;
+    private final DiagnosticCollector<JavaFileObject> diagnostics;
+
+    CompilerVerificationResult(boolean success, DiagnosticCollector<JavaFileObject> diagnostics) {
+        this.success = success;
+        this.diagnostics = diagnostics;
+    }
+
+    public boolean successfullyCompiled() {
+        return success;
+    }
+
+    public String diagnosticsMessages() {
+        return diagnostics.getDiagnostics().stream()
+                .map(diagnostic -> diagnostic.getMessage(Locale.getDefault()))
+                .collect(Collectors.joining("\n"));
+    }
+}

--- a/tyler-base/src/test/java/ch/qos/logback/tyler/base/compiler/JavaSourceFromString.java
+++ b/tyler-base/src/test/java/ch/qos/logback/tyler/base/compiler/JavaSourceFromString.java
@@ -1,0 +1,18 @@
+package ch.qos.logback.tyler.base.compiler;
+
+import java.net.URI;
+import javax.tools.SimpleJavaFileObject;
+
+class JavaSourceFromString extends SimpleJavaFileObject {
+    private final String sourceCode;
+
+    JavaSourceFromString(String name, String sourceCode) {
+        super(URI.create("string:///" + name.replace('.', '/') + Kind.SOURCE.extension), Kind.SOURCE);
+        this.sourceCode = sourceCode;
+    }
+
+    @Override
+    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+        return sourceCode;
+    }
+}


### PR DESCRIPTION
## Changes:

* Add a new verification mechanism to the regression test file
  * This new verification mechanism runs the content of the witness file through the java compiler using the `javax.tools.JavaCompiler` API
  * The returned verification object contains the result of the compilation task as well as a method to get a string containing all the messages reported by the compiler which is useful in the event of a failed compilation.


### Notes
* See #7 for purpose
* @ceki the `sequenceGenerator.xml` test was failing, it looked like it wanted to use the same appender reference from the smoke test so I copied over the config from there. However if there are any changes you want to make to it I would be more than happy to accommodate, I just made it work and I don't know too much about the validity of what I have chosen.